### PR TITLE
Change getters for cod and insurence price return string

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -168,7 +168,7 @@ class Payment
 	 */
 	public function getCodPrice(): string
 	{
-		return number_format($this->codPrice, 4, '.', '');
+		return number_format($this->codPrice, 2, '.', '');
 	}
 
 
@@ -221,7 +221,7 @@ class Payment
 	 */
 	public function getInsurPrice(): string
 	{
-		return number_format($this->insurPrice, 4, '.', '');
+		return number_format($this->insurPrice, 2, '.', '');
 	}
 
 

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -164,11 +164,11 @@ class Payment
 
 
 	/**
-	 * @return float
+	 * @return string
 	 */
-	public function getCodPrice(): float
+	public function getCodPrice(): string
 	{
-		return $this->codPrice;
+		return number_format($this->codPrice, 4, '.', '');
 	}
 
 
@@ -217,11 +217,11 @@ class Payment
 
 
 	/**
-	 * @return float
+	 * @return string
 	 */
-	public function getInsurPrice(): float
+	public function getInsurPrice(): string
 	{
-		return $this->insurPrice;
+		return number_format($this->insurPrice, 4, '.', '');
 	}
 
 

--- a/tests/Payment.phpt
+++ b/tests/Payment.phpt
@@ -10,9 +10,9 @@ $payment = new Payment('DE89 3704 0044 0532 0130 00', 'TATRSKBX', '1201800001', 
 Assert::same('DE89370400440532013000', $payment->getIban());
 Assert::same('TATRSKBX', $payment->getSwift());
 Assert::same('1201800001', $payment->getCodVarSymbol());
-Assert::same(1.99, $payment->getCodPrice());
+Assert::same('1.99', $payment->getCodPrice());
 Assert::same('EUR', $payment->getCodCurrency());
-Assert::same(1000.0, $payment->getInsurPrice());
+Assert::same('1000.0', $payment->getInsurPrice());
 Assert::same('EUR', $payment->getInsurCurrency());
 Assert::same('0308', $payment->getSpecSymbol());
 

--- a/tests/Payment.phpt
+++ b/tests/Payment.phpt
@@ -10,9 +10,9 @@ $payment = new Payment('DE89 3704 0044 0532 0130 00', 'TATRSKBX', '1201800001', 
 Assert::same('DE89370400440532013000', $payment->getIban());
 Assert::same('TATRSKBX', $payment->getSwift());
 Assert::same('1201800001', $payment->getCodVarSymbol());
-Assert::same('1.99', $payment->getCodPrice());
+Assert::same('1.9900', $payment->getCodPrice());
 Assert::same('EUR', $payment->getCodCurrency());
-Assert::same('1000.0', $payment->getInsurPrice());
+Assert::same('1000.0000', $payment->getInsurPrice());
 Assert::same('EUR', $payment->getInsurCurrency());
 Assert::same('0308', $payment->getSpecSymbol());
 

--- a/tests/Payment.phpt
+++ b/tests/Payment.phpt
@@ -10,9 +10,9 @@ $payment = new Payment('DE89 3704 0044 0532 0130 00', 'TATRSKBX', '1201800001', 
 Assert::same('DE89370400440532013000', $payment->getIban());
 Assert::same('TATRSKBX', $payment->getSwift());
 Assert::same('1201800001', $payment->getCodVarSymbol());
-Assert::same('1.9900', $payment->getCodPrice());
+Assert::same('1.99', $payment->getCodPrice());
 Assert::same('EUR', $payment->getCodCurrency());
-Assert::same('1000.0000', $payment->getInsurPrice());
+Assert::same('1000.00', $payment->getInsurPrice());
 Assert::same('EUR', $payment->getInsurCurrency());
 Assert::same('0308', $payment->getSpecSymbol());
 


### PR DESCRIPTION
I send `(float) 2554.88999999999987` and DHL soap return to me


> The formatter threw an exception while trying to deserialize the message: There was an error while trying to deserialize parameter http://myapi.ppl.cz/v1:Packages. The InnerException message was 'There was an error deserializing the object of type System.Collections.Generic.List`1[[Elinkx.EpsNet.API.MyAPI.MyApiPackageIn, Elinkx.EpsNet.API.MyAPI, Version=1.18.409.1958, Culture=neutral, PublicKeyToken=null]]. The value '2554,89' cannot be parsed as the type 'decimal'.'. Please see InnerException for more details.


`2554,89` - not working
`2554.89` - not working
`(float) 2554.89` - not working
`(string) '2554,89'` - not working
`(string) '2554.89'` - it works